### PR TITLE
improve performance, map -> for loop in hot spots

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -3,6 +3,7 @@
 import FS from 'fs'
 
 import log from 'loglevel'
+import { FsEvaluator } from './evaluator.js'
 import { FizzBuzzScheme } from './index.js'
 log.setLevel('info')
 
@@ -21,6 +22,7 @@ export class FsCli {
       const file = argv[i]
       const data = FS.readFileSync(file, 'utf8')
       engine.eval(data)
+      log.info(FsEvaluator.evalCounter)
     }
     process.exit(0)
   }

--- a/src/evaluator.js
+++ b/src/evaluator.js
@@ -7,6 +7,7 @@ import log from 'loglevel'
 
 // Evaluator
 export class FsEvaluator {
+  static evalCounter = 0
   static evalOuter (sexp, env = getGlobalEnv()) {
     if (log.getLevel() <= log.levels.DEBUG) {
       log.debug('----------------------------------------------------')
@@ -22,6 +23,7 @@ export class FsEvaluator {
   }
 
   static eval (sexp, env = getGlobalEnv()) {
+    FsEvaluator.evalCounter++
     if (sexp instanceof FsSymbol) {
       return env.find(sexp)
     } else if (!Array.isArray(sexp)) {
@@ -47,7 +49,16 @@ export class FsEvaluator {
       return FsLet.proc(sexp.slice(1), env)
     } else {
       const p = FsEvaluator.eval(sexp[0], env)
-      const args = sexp.slice(1).map(s => this.eval(s, env))
+
+      // for the readability, use this line
+      // const args = sexp.slice(1).map(s => this.eval(s, env))
+
+      // for the performance, use lines below. it may be bit faster.
+      const args = []
+      for (let i = 1; i < sexp.length; i++) {
+        args.push(FsEvaluator.eval(sexp[i], env))
+      }
+
       // return p.proc(args)
       return p.proc(args, env) // for testing map
     }

--- a/src/sexp.js
+++ b/src/sexp.js
@@ -346,7 +346,16 @@ export class FsOperatorAbs extends FsSExp {
 
 export class FsOperatorPlus extends FsSExp {
   static proc (list) {
-    return new FsNumber(list.map(n => n.value).reduce((a, b) => a + b, 0))
+    // for the readability, use this line
+    // return new FsNumber(list.map(n => n.value).reduce((a, b) => a + b, 0))
+
+    // for the performance, use lines below. it may be bit faster.
+    //
+    let buf = 0
+    for (let i = 0; i < list.length; i++) {
+      buf += list[i].value
+    }
+    return new FsNumber(buf)
   }
 }
 
@@ -367,14 +376,16 @@ export class FsOperatorMinus extends FsSExp {
     if (list.length === 1) {
       return new FsNumber(-1 * (list[0].value))
     } else {
-      return new FsNumber(list[0].value - FsOperatorPlus.proc(list.slice(1)))
+      // for the readability, use this line
+      // return new FsNumber(list[0].value - FsOperatorPlus.proc(list.slice(1)))
+
       // for the performance, use lines below. it may be bit faster.
       //
-      // let buf = list[0].value
-      // for (let i = 1; i < list.length; i++) {
-      //   buf -= list[i]
-      // }
-      // return new FsNumber(buf)
+      let buf = list[0].value
+      for (let i = 1; i < list.length; i++) {
+        buf -= list[i]
+      }
+      return new FsNumber(buf)
     }
   }
 }


### PR DESCRIPTION
current impl

0 7.2356292
1 7.0686887
2 7.3410158
3 7.1168161
4 7.2064028
avg.
+
7.19371052


quit log-wrapper for evalInner()

0 6.7304851
1 6.7530081
2 6.7564883
3 6.5836181
4 6.6060654
avg. 6.685933

=> 7% faster


map->for loop in the last part of eval() function
0 6.1171146
1 5.9302818
2 6.1266277
3 5.9285433
4 6.1319536
avg. 6.0469042

map->for loop in FsOperatorMinus

0 5.9562005
1 5.7529578
2 5.6595869
3 5.7532404
4 5.7406183
avg. 5.77252078

=> 20% faster than current impl
